### PR TITLE
Fixed sendInvoice method so that it will update the invoice object after sending

### DIFF
--- a/Api.php
+++ b/Api.php
@@ -912,9 +912,11 @@ class MoneybirdApi {
 		$sendinfo->invoice_id = $invoice->id;
 
 		// Send
-		$this->request(
+		$response = $this->request(
 			'invoices/' . $invoice->id . '/send_invoice', 'PUT', $sendinfo
 		);
+
+		$invoice->fromXML($response);
 	}
 
 	/**


### PR DESCRIPTION
You don't get the invoice_id when you send the invoice. You'll have to fetch the invoice again. This is a bit ridiculous because the /send_invoice API endpoint gives you this information.

```
<?php
$invoice = new MoneybirdInvoice;
$api->saveInvoice($invoice);

$invoice->markAsSent();

echo $invoice->invoice_id;  // unknown

$invoice = $api->getInvoice($invoice->id);

echo $invoice->invoice_id; // gives a valid value
?>
```

So this PR updates the invoice object with the latest information.

This should probably be done everywhere but I don't need that ATM.
