### PR TITLE
'credit_invoice' missing from payment method list

### DIFF
--- a/Payment/Abstract.php
+++ b/Payment/Abstract.php
@@ -33,11 +33,12 @@ abstract class Payment_Abstract extends Domainmodel_Abstract implements Mapper_M
 	 * @var Array
 	 */
 	protected $_paymentMethods = array(
-		'bank_transfer', 
-		'creditcard', 
-		'direct_debit', 
-		'ideal', 
-		'paypal', 
+		'bank_transfer',
+		'creditcard',
+		'credit_invoice',
+		'direct_debit',
+		'ideal',
+		'paypal',
 		'pin',
 	);
 	


### PR DESCRIPTION
The Payment/Abstract.php "Payment_Abstract" class seems to miss the "credit_invoice" payment method.

``` php
    /**
     * Allowed payment methods
     * @var Array
     */
    protected $_paymentMethods = array(
        'bank_transfer',
        'creditcard',
        'direct_debit',
        'ideal',
        'paypal',
        'pin',
    );
```

This presents me with an error when fetching payments for a credited invoice.
Pull request is coming up.
