### PR TITLE
Escaping all xml unsafe characters (< > ' ")

### DIFF
--- a/SimpleXMLElement.php
+++ b/SimpleXMLElement.php
@@ -40,7 +40,15 @@ class SimpleXMLElement extends \SimpleXMLElement {
 	 * @return SimpleXMLElement The addChild method returns a SimpleXMLElement object representing the child added to the XML node.
 	 */
 	public function addChild ($key, $value = null, $namespace = null) {
-		return parent::addChild($key, str_replace('&', '&amp;', $value), $namespace);
+		return parent::addChild(
+			$key,
+			str_replace(
+				array("&", "<", ">", "\"", "'"),
+				array("&amp;", "&lt;", "&gt;", "&quot;", "&apos;"),
+				$value
+			),
+			$namespace
+		);
     } 
 
 	/**

--- a/tests/ContactTest.php
+++ b/tests/ContactTest.php
@@ -70,12 +70,12 @@ class ContactTest extends \PHPUnit_Framework_TestCase {
 			'bankAccount' => 'Bank account', 
 			'chamberOfCommerce' => '1234567', 
 			'city' => 'City name', 
-			'companyName' => 'My Test & company', 
+			'companyName' => 'My Test & < > \' \ company',
 			'contactName' => 'Contact name', 
 			'country' => 'Country name', 
 			'customerId' => self::$customerId, 
 			'email' => 'email@fake.fake', 
-			'firstname' => 'John', 
+			'firstname' => 'John',
 			'lastname' => 'Doe', 
 			'phone' => '073-1234567', 
 			'sendMethod' => 'email', 
@@ -87,7 +87,7 @@ class ContactTest extends \PHPUnit_Framework_TestCase {
 		self::$contactId = $contact->id;
 		$this->assertNotNull(self::$contactId);
 		$this->assertGreaterThan(0, self::$contactId);
-		$this->assertEquals($contact->companyName, 'My Test & company');
+		$this->assertEquals('My Test & < > \' \ company', $contact->companyName);
 	}
 	
 	/**


### PR DESCRIPTION
#30 is about the escaping of &, but the other four XML unsafe chars are left out. This (still) fixes both the ampersand and the < > '  " characters. Added them to the ContactTest as well.
