### PR TITLE
requestsLeft() now works without making a request first

### DIFF
--- a/ApiConnector.php
+++ b/ApiConnector.php
@@ -166,6 +166,7 @@ class ApiConnector {
 	 * @return int
 	 */
 	public function requestsLeft() {
+		$this->testLogin();
 		return $this->transport->requestsLeft();
 	}
 	


### PR DESCRIPTION
It is now possible to get the requestsLeft before you actually make a API call.
