### PR TITLE
HttpClient::$verifyHostAndPeer = 2

### DIFF
--- a/HttpClient.php
+++ b/HttpClient.php
@@ -62,10 +62,10 @@ class HttpClient implements Transport {
 	 * Verify host and peer
 	 * 
 	 * @access protected
-	 * @var bool
+	 * @var int
 	 * @static
 	 */
-	public static $verifyHostAndPeer = true;
+	public static $verifyHostAndPeer = 2;
 	
 	/**
 	 * Creates connector object


### PR DESCRIPTION
This value should be of type int instead of boolean. The PHP Docs say it should be int 2 for production.

Please merge + tag.

```
[ErrorException]                                                                                                     
  Notice: curl_setopt_array(): CURLOPT_SSL_VERIFYHOST set to true which disables common name validation (setting CURL  
  OPT_SSL_VERIFYHOST to 2 enables common name validation) in /../HttpClient.php line 148 
```

From the docs:

```
CURLOPT_SSL_VERIFYHOST   
1 to check the existence of a common name in the SSL peer certificate. 2 to check the existence of a common name and also verify that it matches the hostname provided. In production environments the value of this option should be kept at 2 (default value).
```
