### PR TITLE
HTTP header names are case insensitive

### DIFF
--- a/HttpClient.php
+++ b/HttpClient.php
@@ -250,7 +250,7 @@ class HttpClient implements Transport
             // No requests made yet
             return null;
         }
-        return $headers['X-RateLimit-Remaining'];
+        return $headers['x-ratelimit-remaining'];
     }
 
     /**
@@ -409,7 +409,7 @@ class HttpClient implements Transport
         $matches = array();
         if (preg_match_all('/([\w-]+): (.*)/', $this->lastHeader, $matches)) {
             for ($i = count($matches[0]) - 1; $i >= 0; $i--) {
-                $headers[$matches[1][$i]] = $matches[2][$i];
+                $headers[strtolower($matches[1][$i])] = $matches[2][$i];
             }
         }
         return $headers;


### PR DESCRIPTION
HTTP header names are case insensitive. The "X-RateLimit-Remaining" header was changed to "x-ratelimit-remaining" in the API. See http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2